### PR TITLE
Adjusted links to use the .org domain and HTTPS.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Welcome to [freeCodeCamp's](https://www.freeCodeCamp.org) Asset Repository
+Welcome to [freeCodeCamp's](https://freeCodeCamp.org) Asset Repository
 =====================================================================
 
 This is where we store all of the design assets for freeCodeCamp's open source community.
@@ -11,4 +11,4 @@ Please feel free to use these assets to promote freeCodeCamp or your city's camp
 
 Though these assets are Creative Commons licensed, we're trademarking the name "freeCodeCamp" itself to prevent scammers from trying to impersonate our organization. If you have questions about this, email us and we'll reply promptly: team at freeCodeCamp com.
 
-<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/StillImage" property="dct:title" rel="dct:type">freeCodeCamp</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://www.freeCodeCamp.org" property="cc:attributionName" rel="cc:attributionURL">freeCodeCamp</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.<br />Based on a work at <a xmlns:dct="http://purl.org/dc/terms/" href="https://www.freeCodeCamp.org" rel="dct:source">https://www.freeCodeCamp.org</a>.
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/StillImage" property="dct:title" rel="dct:type">freeCodeCamp</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://freeCodeCamp.org" property="cc:attributionName" rel="cc:attributionURL">freeCodeCamp</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.<br />Based on a work at <a xmlns:dct="http://purl.org/dc/terms/" href="https://freeCodeCamp.org" rel="dct:source">https://freeCodeCamp.org</a>.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Welcome to [freeCodeCamp's](http://freeCodeCamp.com) Asset Repository
+Welcome to [freeCodeCamp's](https://www.freeCodeCamp.org) Asset Repository
 =====================================================================
 
 This is where we store all of the design assets for freeCodeCamp's open source community.
@@ -11,4 +11,4 @@ Please feel free to use these assets to promote freeCodeCamp or your city's camp
 
 Though these assets are Creative Commons licensed, we're trademarking the name "freeCodeCamp" itself to prevent scammers from trying to impersonate our organization. If you have questions about this, email us and we'll reply promptly: team at freeCodeCamp com.
 
-<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/StillImage" property="dct:title" rel="dct:type">freeCodeCamp</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="http://freeCodeCamp.com" property="cc:attributionName" rel="cc:attributionURL">freeCodeCamp</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.<br />Based on a work at <a xmlns:dct="http://purl.org/dc/terms/" href="http://freeCodeCamp.com" rel="dct:source">http://freeCodeCamp.com</a>.
+<a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a><br /><span xmlns:dct="http://purl.org/dc/terms/" href="http://purl.org/dc/dcmitype/StillImage" property="dct:title" rel="dct:type">freeCodeCamp</span> by <a xmlns:cc="http://creativecommons.org/ns#" href="https://www.freeCodeCamp.org" property="cc:attributionName" rel="cc:attributionURL">freeCodeCamp</a> is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/">Creative Commons Attribution-ShareAlike 4.0 International License</a>.<br />Based on a work at <a xmlns:dct="http://purl.org/dc/terms/" href="https://www.freeCodeCamp.org" rel="dct:source">https://www.freeCodeCamp.org</a>.


### PR DESCRIPTION
This updates the links to use the freecodecamp.org domain name as opposed to the old freecodecamp.com domain name, links also use HTTPS now.